### PR TITLE
documentation improvement suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,52 @@
 # Synapse-ETL-Jobs
-Synapse ETL jobs project will be maintaining all the glue job scripts.All the data which is currently processed by 
-Synapse-Warehouse-Workers and stored in RDS should be moved to Synapse-ETL-Jobs and stored in s3 which will be queried
-by athena. Synapse-ETL-Jobs project is maintaining the python scripts which will be executed by glue jobs.Once the 
-python script created in Synapse-ETL-Jobs project, the cloud formation of glue job and related resources should be done
-in Synapse-Stack-Builder project.For more information please see the[design documentation](https://sagebionetworks.jira.com/wiki/spaces/DW/pages/2732916846/Processing+Access+Records+using+AWS+High+Level+Design)
+The Synapse ETL jobs project maintains all the Python-based Glue job scripts respoonsible for moving 
+Synapse Warehouse data to S3 where it can be queried by Athena. 
+The scripts are deployed to S3, from where the Synapse Stack Builder can include them in a Glue
+CloudFormation stack it creates.
+For more information please see the [design documentation](https://sagebionetworks.jira.com/wiki/spaces/DW/pages/2732916846/Processing+Access+Records+using+AWS+High+Level+Design).
 
-# Repo structure
-This repository only contains the python scripts which is used by glue job.
+# Repository structure
+This repository only contains the Python scripts which are used by Glue jobs.
 
 ### `src/`
-The `src` directory contains job scripts
+This directory contains job scripts.
 
 ### `tests/`
-This directory contains unit tests
+This directory contains unit tests.
 
 ### `.github/`
 This directory contains the scripts for our GitHub Actions.
 
 # Local environment setup
-The project is using aws-glue libraries and python.To run the test locally we need docker image.
+The project uses AWS Glue libraries and Python, and requires Docker.
 
-To install python on Mac use below command.Python version 3 should be installed. 
-PIP (PIP is a package manager for Python packages, or modules )is included in python version 3.4 or later.
+To install Python on MacOS use the command below, which requires Python version 3 to be installed. 
+PIP (PIP is a package manager for Python packages, or modules ) is included in python version 3.4 or later.
 
 ```
 brew install python
 ```
 
-To run the test we need docker image so we can run test in it.
+The following steps build and run a Docker container.
 
 Build image
+
 ```
 docker build -t aws-glue .
 ```
-To run tests use below command.It will execute the test files, name starts with test.
+
+To run tests use the following command. It will execute the test files, whose names start with test.
+
 ```
 docker run -v ~/.aws:/home/glue_user/.aws -v  ${GITHUB_WORKSPACE}:/home/glue_user/workspace/  -e DISABLE_SSL=true --rm -p 4040:4040 -p 18080:18080  aws-glue -c "python3 -m pytest"
 ```
 
 # GitHub Actions
-1. python-package.yml : This action setup python,install dependencies and check syntax errors or undefined names. 
-Also, it builds the docker image and run tests.
+
+1. python-package.yml : This action sets up python, installs dependencies and checks syntax errors or undefined names. 
+Also, it builds the docker image and run the tests.
+
 2. tag_release.yml : A GitHub action to automatically bump and tag develop, on merge, with the latest 
-SemVer formatted(Major.Minor.Path) version. Minor type of bump is used when none explicitly provided eg(0.1.0).
-If we want to bump specific like major,minor,path or combination then use #major in commit message for major.
-please see the [documentation](https://github.com/anothrNick/github-tag-action)
+SemVer formatted (Major.Minor.Patch) version. If no version is provided, the `Minor` field is bumped.
+The desired bump can be specified in the commit message, e.g. with `#major`, `#minor`, or `#patch`.  For more information,
+please see the [documentation](https://github.com/anothrNick/github-tag-action).


### PR DESCRIPTION
The writing style in the README can use some improvement.
Additionally, I'm not sure it's correct to say that Python is required on the local machine to run the tests, since Python appears instead to run in a container.
In the Docker run command, why do you open those two ports?